### PR TITLE
Updated CoreEditor prerequisite max version to be 16.0 exclusive

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -1,30 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="e5f7e157-f686-46b7-a588-85b08cdaa5f0" Version="2.0" Language="en-US" Publisher="Chris Lajoie" />
-    <DisplayName>Duplicate Selection</DisplayName>
-    <Description xml:space="preserve">Adds a command to duplicate the current selection (or line). Please see the More Info link for keybinding information.</Description>
-    <MoreInfo>https://github.com/ctlajoie/DupSelection</MoreInfo>
-    <License>license.txt</License>
-    <Icon>dupsel-icon.png</Icon>
-    <PreviewImage>dupsel-screenshot.png</PreviewImage>
-    <Tags>Coding, Productivity, Copy, Duplicate, Selection, Line, Duplicate Line</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Ultimate" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.0,]" />
-    <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" Version="[11.0,12.0)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,15.0]" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="e5f7e157-f686-46b7-a588-85b08cdaa5f0" Version="2.0" Language="en-US" Publisher="Chris Lajoie" />
+        <DisplayName>Duplicate Selection</DisplayName>
+        <Description xml:space="preserve">Adds a command to duplicate the current selection (or line). Please see the More Info link for keybinding information.</Description>
+        <MoreInfo>https://github.com/ctlajoie/DupSelection</MoreInfo>
+        <License>license.txt</License>
+        <Icon>dupsel-icon.png</Icon>
+        <PreviewImage>dupsel-screenshot.png</PreviewImage>
+        <Tags>Coding, Productivity, Copy, Duplicate, Selection, Line, Duplicate Line</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Premium" />
+        <InstallationTarget Version="[11.0,15.0]" Id="Microsoft.VisualStudio.Ultimate" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.0,]" />
+        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" Version="[11.0,12.0)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,16.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
Updated CoreEditor prerequisite max version to be 16.0 exclusive instead of 15.0 inclusive; Fixes installation in Visual Studio 15.6 where version was increased from 15.0 to 15.6